### PR TITLE
hotfix: add /users route so dashboard link works

### DIFF
--- a/app.py
+++ b/app.py
@@ -2152,6 +2152,7 @@ def invoices_retention_export_view():
     p.showPage(); p.save(); buf.seek(0)
     return send_file(buf, as_attachment=True, download_name=f"invoices_retention_{cutoff}.pdf", mimetype='application/pdf')
 
+@app.route('/users')
 @require_perm('users','view')
 def users():
     us = User.query.order_by(User.username.asc()).all()


### PR DESCRIPTION
Add missing `@app.route('/users')` above `users()` so `url_for('users')` in dashboard works without 500.

No behavior change besides exposing the page URL that already existed with permissions.

After merge, click Deploy latest commit on Render.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author