### PR TITLE
fix: add /pos/<branch_code> route and minimal pos_home.html to avoid /sales 500

### DIFF
--- a/app.py
+++ b/app.py
@@ -218,6 +218,15 @@ def dashboard():
 
 @app.route('/logout')
 @login_required
+@app.route('/pos/<branch_code>')
+@login_required
+def pos_home(branch_code):
+    # Minimal POS home to avoid template errors; integrate with real POS later
+    if branch_code not in ('place_india','china_town'):
+        flash(_('Unknown branch / فرع غير معروف'), 'danger')
+        return redirect(url_for('dashboard'))
+    return render_template('pos_home.html', branch_code=branch_code)
+
 def logout():
     logout_user()
     flash(_('تم تسجيل الخروج / Logged out.'), 'info')

--- a/templates/pos_home.html
+++ b/templates/pos_home.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block title %}{{ _('POS / نقاط البيع') }}{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h3 class="mb-3">{{ _('Tables (POS) / الطاولات') }} — {{ branch_code|replace('_',' ')|title }}</h3>
+  <p class="text-muted">{{ _('This is a placeholder POS home. Your actual POS UI will load here for this branch.') }}</p>
+  <div class="d-flex gap-2">
+    <a class="btn btn-primary" href="{{ url_for('sales_branch', branch_code=branch_code) }}">{{ _('Back to Sales / الرجوع للمبيعات') }}</a>
+    <a class="btn btn-outline-secondary" href="{{ url_for('dashboard') }}">{{ _('Dashboard / لوحة التحكم') }}</a>
+  </div>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
Adds a minimal `/pos/<branch_code>` route and a placeholder template `pos_home.html` so that the sales branch cards page can link to POS without causing a 500 if POS views aren't present.

- Route: /pos/<branch_code>
- Template: templates/pos_home.html

This unblocks the new `/sales` branch-cards page. Real POS UI can replace the placeholder later.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author