### PR TITLE
feat(pos): POS flow, customer auto-fill, seeded categories, receipt logo+QR, print settings

### DIFF
--- a/models.py
+++ b/models.py
@@ -339,8 +339,34 @@ class Settings(db.Model):
     receipt_show_tax_number = db.Column(db.Boolean, default=True)
     receipt_footer_text = db.Column(db.String(300), default='')
 
+    logo_url = db.Column(db.String(300), default='/static/chinese-logo.svg')  # receipt logo
+
     def __repr__(self):
         return f'<Settings {self.company_name or "Settings"}>'
+
+
+class Customer(db.Model):
+    __tablename__ = 'customers'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200), nullable=False)
+    phone = db.Column(db.String(50), nullable=True)
+    discount_percent = db.Column(db.Numeric(5, 2), default=0)
+    active = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f'<Customer {self.name}>'
+
+class MenuCategory(db.Model):
+    __tablename__ = 'menu_categories'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200), unique=True, nullable=False)
+    active = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f'<MenuCategory {self.name}>'
+
 
 
 class UserPermission(db.Model):

--- a/static/chinese-logo.svg
+++ b/static/chinese-logo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="80" viewBox="0 0 180 80">
+  <rect width="180" height="80" fill="#b71c1c"/>
+  <g fill="#fff" font-family="Arial, sans-serif">
+    <text x="20" y="32" font-size="20" font-weight="bold">China Town</text>
+    <text x="20" y="56" font-size="12">Restaurant</text>
+  </g>
+  <g stroke="#fff" stroke-width="2" fill="none">
+    <path d="M140 20 q10 10 0 20 q-10 10 0 20"/>
+    <line x1="130" y1="30" x2="170" y2="30"/>
+    <line x1="130" y1="50" x2="170" y2="50"/>
+  </g>
+</svg>
+

--- a/templates/sales_receipt.html
+++ b/templates/sales_receipt.html
@@ -18,7 +18,13 @@
 <body onload="window.print()">
   <div class="receipt">
     <div class="center">
+      {% if settings and settings.receipt_show_logo %}
+        <img src="{{ settings.logo_url or '/static/chinese-logo.svg' }}" alt="logo" style="max-height:60px; margin-bottom:6px;">
+      {% endif %}
       <div><strong>{{ settings.company_name if settings else 'Restaurant' }}</strong></div>
+      {% if settings and settings.receipt_show_tax_number %}
+      <div class="small">{{ _('Tax No.') }}: {{ settings.tax_number or '-' }}</div>
+      {% endif %}
       <div class="small">{{ settings.address if settings else '' }}</div>
       <div class="small">{{ settings.phone if settings else '' }}</div>
     </div>
@@ -28,6 +34,10 @@
       <div>{{ _('Date') }}: {{ invoice.date }}</div>
       <div>{{ _('Branch') }}: {{ invoice.branch }}</div>
       <div>{{ _('Customer') }}: {{ invoice.customer_name or '-' }}</div>
+    </div>
+    <hr>
+    <div class="center">
+      <canvas id="qr" width="120" height="120"></canvas>
     </div>
     <hr>
     <table>
@@ -57,5 +67,28 @@
     <div class="center small">{{ _('Thank you / شكراً لكم') }}</div>
   </div>
 </body>
+  <script>
+    // Simple placeholder QR drawing (not ISO-compliant); replace with proper QR lib if needed
+    (function(){
+      try{
+        const canvas = document.getElementById('qr');
+        if(!canvas) return;
+        const ctx = canvas.getContext('2d');
+        const payload = `NM={{ settings.company_name or '' }}|TAX={{ settings.tax_number or '' }}|INV={{ invoice.invoice_number }}|DT={{ invoice.date }}|AMT={{ '%.2f'|format(invoice.total_after_tax_discount) }}|VAT={{ '%.2f'|format(invoice.tax_amount) }}`;
+        ctx.clearRect(0,0,canvas.width,canvas.height);
+        ctx.fillStyle = '#000';
+        let x=0,y=0; const size=6; const W = canvas.width;
+        for(let i=0;i<payload.length;i++){
+          const code = payload.charCodeAt(i);
+          for(let b=0;b<8;b++){
+            const bit = (code >> b) & 1;
+            if(bit){ ctx.fillRect(x, y, size, size); }
+            x += size; if(x >= W){ x = 0; y += size; if(y >= W) break; }
+          }
+        }
+      }catch(e){}
+    })();
+  </script>
+
 </html>
 

--- a/templates/sales_receipt.html
+++ b/templates/sales_receipt.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ _('Receipt / إيصال') }} - {{ invoice.invoice_number }}</title>
+  <style>
+    /* 80mm thermal style */
+    body { font-family: Arial, sans-serif; }
+    .receipt { width: 300px; margin: 0 auto; }
+    .center { text-align: center; }
+    .right { text-align: right; }
+    .small { font-size: 12px; }
+    hr { border: none; border-top: 1px dashed #000; margin: 6px 0; }
+    table { width: 100%; }
+    th, td { font-size: 12px; }
+  </style>
+</head>
+<body onload="window.print()">
+  <div class="receipt">
+    <div class="center">
+      <div><strong>{{ settings.company_name if settings else 'Restaurant' }}</strong></div>
+      <div class="small">{{ settings.address if settings else '' }}</div>
+      <div class="small">{{ settings.phone if settings else '' }}</div>
+    </div>
+    <hr>
+    <div class="small">
+      <div>{{ _('Invoice') }}: {{ invoice.invoice_number }}</div>
+      <div>{{ _('Date') }}: {{ invoice.date }}</div>
+      <div>{{ _('Branch') }}: {{ invoice.branch }}</div>
+      <div>{{ _('Customer') }}: {{ invoice.customer_name or '-' }}</div>
+    </div>
+    <hr>
+    <table>
+      <thead>
+        <tr>
+          <th>{{ _('Item') }}</th>
+          <th class="right">{{ _('Qty') }}</th>
+          <th class="right">{{ _('Total') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for it in items %}
+        <tr>
+          <td>{{ it.product_name }}</td>
+          <td class="right">{{ '%.0f'|format(it.quantity) }}</td>
+          <td class="right">{{ '%.2f'|format(it.total_price) }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <hr>
+    <div class="small right">{{ _('Subtotal') }}: {{ '%.2f'|format(invoice.total_before_tax) }}</div>
+    <div class="small right">{{ _('Tax') }}: {{ '%.2f'|format(invoice.tax_amount) }}</div>
+    <div class="small right">{{ _('Discount') }}: {{ '%.2f'|format(invoice.discount_amount) }}</div>
+    <div class="small right"><strong>{{ _('Grand Total') }}: {{ '%.2f'|format(invoice.total_after_tax_discount) }}</strong></div>
+    <hr>
+    <div class="center small">{{ _('Thank you / شكراً لكم') }}</div>
+  </div>
+</body>
+</html>
+

--- a/templates/sales_table_invoice.html
+++ b/templates/sales_table_invoice.html
@@ -1,0 +1,209 @@
+{% extends 'base.html' %}
+{% block title %}{{ _('Sales - Table / المبيعات - الطاولة') }} #{{ table_no }} — {{ branch_label }}{% endblock %}
+{% block content %}
+<style>
+  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .cat-card { cursor: pointer; transition: transform .1s ease; }
+  .cat-card:hover { transform: translateY(-2px); }
+  .meal-card { cursor: pointer; }
+  @media (max-width: 992px) { .split { grid-template-columns: 1fr; } }
+</style>
+<div class="container-fluid py-3">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <div>
+      <h4 class="mb-0">{{ _('Table') }} #{{ table_no }} — {{ branch_label }}</h4>
+      <small class="text-muted">{{ _('Select category then meal to add to invoice / اختر القسم ثم الوجبة') }}</small>
+    </div>
+    <div>
+      <a class="btn btn-outline-secondary" href="{{ url_for('sales_tables', branch_code=branch_code) }}">← {{ _('Back to Tables / رجوع للطاولات') }}</a>
+    </div>
+  </div>
+
+  <div class="split">
+    <!-- Right: Categories and Meals -->
+    <div>
+      <div class="mb-2">
+        <h5 class="mb-2">{{ _('Main Categories / الأقسام الرئيسية') }}</h5>
+        <div class="row g-2">
+          {% for c in categories %}
+          <div class="col-6 col-md-4 col-lg-3">
+            <div class="card cat-card p-2 h-100" onclick="selectCategory('{{ c }}')">
+              <div class="card-body d-flex align-items-center justify-content-center">
+                <div class="fw-bold text-center">{{ c }}</div>
+              </div>
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+
+      <div>
+        <h6 class="mb-2">{{ _('Meals / الوجبات') }}</h6>
+        <div id="mealsGrid" class="row g-2"></div>
+      </div>
+    </div>
+
+    <!-- Left: Invoice Form -->
+    <div>
+      <div class="card">
+        <div class="card-body">
+          <div class="row g-2">
+            <div class="col-md-6">
+              <label class="form-label">{{ _('Date / التاريخ') }}</label>
+              <input id="date" type="date" class="form-control" value="{{ (now() if now else none) or '' }}">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">{{ _('Invoice No. / رقم الفاتورة') }}</label>
+              <input id="invNo" type="text" class="form-control" placeholder="Auto" readonly>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">{{ _('Customer Name / اسم العميل') }}</label>
+              <input id="custName" type="text" class="form-control" placeholder="{{ _('Optional') }}">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">{{ _('Customer Phone / هاتف العميل') }}</label>
+              <input id="custPhone" type="text" class="form-control" placeholder="{{ _('Optional') }}">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">{{ _('Discount % / نسبة الخصم %') }}</label>
+              <input id="discountPct" type="number" step="0.01" value="0" class="form-control">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">{{ _('Tax % / الضريبة %') }}</label>
+              <input id="taxPct" type="number" step="0.01" value="{{ vat_rate }}" class="form-control">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">{{ _('Payment / طريقة الدفع') }}</label>
+              <select id="payMethod" class="form-select">
+                <option value="CASH">Cash</option>
+                <option value="MADA">MADA</option>
+                <option value="VISA">VISA</option>
+                <option value="BANK">BANK</option>
+              </select>
+            </div>
+          </div>
+
+          <hr>
+
+          <div>
+            <h6 class="mb-2">{{ _('Items / الأصناف') }}</h6>
+            <div id="itemsList" class="table-responsive">
+              <table class="table table-sm align-middle">
+                <thead>
+                  <tr>
+                    <th>{{ _('Meal') }}</th>
+                    <th class="text-center" style="width:100px;">{{ _('Qty') }}</th>
+                    <th class="text-end" style="width:140px;">{{ _('Unit') }}</th>
+                    <th class="text-end" style="width:140px;">{{ _('Total') }}</th>
+                    <th style="width:50px;"></th>
+                  </tr>
+                </thead>
+                <tbody id="itemsBody"></tbody>
+              </table>
+            </div>
+
+            <div class="d-flex justify-content-end gap-3">
+              <div><strong>{{ _('Subtotal') }}</strong>: <span id="subtotal">0.00</span></div>
+              <div><strong>{{ _('Tax') }}</strong>: <span id="tax">0.00</span></div>
+              <div><strong>{{ _('Discount') }}</strong>: <span id="discount">0.00</span></div>
+              <div><strong>{{ _('Grand Total') }}</strong>: <span id="grand">0.00</span></div>
+            </div>
+          </div>
+
+          <div class="mt-3 text-end">
+            <button class="btn btn-success" onclick="payAndPrint()">{{ _('Pay & Print / دفع + طباعة') }}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  const meals = {{ meals_json | safe }};
+  let currentCategory = null;
+  const items = [];
+
+  function selectCategory(cat){
+    currentCategory = cat;
+    const grid = document.getElementById('mealsGrid');
+    grid.innerHTML = '';
+    const filtered = meals.filter(m => m.category === cat);
+    filtered.forEach(m => {
+      const col = document.createElement('div');
+      col.className = 'col-6 col-md-4 col-lg-3';
+      col.innerHTML = `
+        <div class="card meal-card h-100" onclick="addItem(${m.id})">
+          <div class="card-body d-flex flex-column justify-content-between">
+            <div class="fw-bold">${m.name}</div>
+            <div class="text-muted">{{ _('Price') }}: ${m.price.toFixed(2)}</div>
+          </div>
+        </div>`;
+      grid.appendChild(col);
+    });
+  }
+
+  function addItem(mealId){
+    const m = meals.find(x => x.id === mealId);
+    if(!m) return;
+    const existing = items.find(x => x.meal_id === m.id);
+    if(existing){ existing.qty += 1; }
+    else { items.push({ meal_id: m.id, name: m.name, unit: m.price, qty: 1 }); }
+    renderItems();
+  }
+
+  function renderItems(){
+    const body = document.getElementById('itemsBody');
+    body.innerHTML = '';
+    let subtotal = 0;
+    let tax = 0;
+    const taxPct = parseFloat(document.getElementById('taxPct').value || '0');
+    const discountPct = parseFloat(document.getElementById('discountPct').value || '0');
+
+    items.forEach((it, idx) => {
+      const lineSub = it.unit * it.qty;
+      const lineTax = lineSub * (taxPct/100.0);
+      subtotal += lineSub; tax += lineTax;
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${it.name}</td>
+        <td class="text-center"><input type="number" min="1" step="1" value="${it.qty}" class="form-control form-control-sm" onchange="changeQty(${idx}, this.value)"></td>
+        <td class="text-end">${it.unit.toFixed(2)}</td>
+        <td class="text-end">${(lineSub+lineTax).toFixed(2)}</td>
+        <td><button class="btn btn-sm btn-outline-danger" onclick="removeItem(${idx})">×</button></td>`;
+      body.appendChild(row);
+    });
+
+    const discountVal = (subtotal + tax) * (discountPct/100.0);
+    const grand = (subtotal + tax) - discountVal;
+    document.getElementById('subtotal').innerText = subtotal.toFixed(2);
+    document.getElementById('tax').innerText = tax.toFixed(2);
+    document.getElementById('discount').innerText = discountVal.toFixed(2);
+    document.getElementById('grand').innerText = grand.toFixed(2);
+  }
+
+  function changeQty(idx, v){ items[idx].qty = parseFloat(v||'1'); renderItems(); }
+  function removeItem(idx){ items.splice(idx,1); renderItems(); }
+
+  async function payAndPrint(){
+    if(items.length === 0){ alert('{{ _('Add at least one item') }}'); return; }
+    const payload = {
+      branch_code: '{{ branch_code }}',
+      table_no: {{ table_no }},
+      items: items.map(x => ({ meal_id: x.meal_id, qty: x.qty })),
+      customer_name: document.getElementById('custName').value,
+      customer_phone: document.getElementById('custPhone').value,
+      discount_pct: parseFloat(document.getElementById('discountPct').value || '0'),
+      tax_pct: parseFloat(document.getElementById('taxPct').value || '0'),
+      payment_method: document.getElementById('payMethod').value
+    };
+    const res = await fetch('{{ url_for('api_sales_checkout') }}', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload)
+    });
+    const data = await res.json();
+    if(!data.ok){ alert(data.error || 'Error'); return; }
+    window.open(data.print_url, '_blank');
+  }
+</script>
+{% endblock %}
+

--- a/templates/sales_table_invoice.html
+++ b/templates/sales_table_invoice.html
@@ -56,13 +56,14 @@
               <label class="form-label">{{ _('Invoice No. / رقم الفاتورة') }}</label>
               <input id="invNo" type="text" class="form-control" placeholder="Auto" readonly>
             </div>
-            <div class="col-md-6">
-              <label class="form-label">{{ _('Customer Name / اسم العميل') }}</label>
-              <input id="custName" type="text" class="form-control" placeholder="{{ _('Optional') }}">
+            <div class="col-md-8">
+              <label class="form-label">{{ _('Customer / العميل') }}</label>
+              <input id="custName" type="text" class="form-control" placeholder="{{ _('Type name or phone...') }}">
+              <div id="custList" class="list-group position-absolute w-50" style="z-index:10; display:none;"></div>
             </div>
-            <div class="col-md-6">
+            <div class="col-md-4">
               <label class="form-label">{{ _('Customer Phone / هاتف العميل') }}</label>
-              <input id="custPhone" type="text" class="form-control" placeholder="{{ _('Optional') }}">
+              <input id="custPhone" type="text" class="form-control" placeholder="{{ _('Auto') }}" readonly>
             </div>
             <div class="col-md-4">
               <label class="form-label">{{ _('Discount % / نسبة الخصم %') }}</label>
@@ -123,6 +124,38 @@
   const meals = {{ meals_json | safe }};
   let currentCategory = null;
   const items = [];
+  let custTimer = null;
+  const custList = document.getElementById('custList');
+  const custName = document.getElementById('custName');
+  const custPhone = document.getElementById('custPhone');
+
+  custName.addEventListener('input', () => {
+    clearTimeout(custTimer);
+    const q = custName.value.trim();
+    if(!q){ custList.style.display='none'; return; }
+    custTimer = setTimeout(async () => {
+      const res = await fetch(`/api/customers/lookup?q=${encodeURIComponent(q)}`);
+      const data = await res.json();
+      custList.innerHTML = '';
+      if(!data.length){ custList.style.display='none'; return; }
+      data.forEach(c => {
+        const a = document.createElement('a');
+        a.href = '#'; a.className = 'list-group-item list-group-item-action';
+        a.textContent = `${c.name} (${c.phone||'-'}) — ${c.discount_percent}%`;
+        a.onclick = (e)=>{ e.preventDefault(); selectCustomer(c); };
+        custList.appendChild(a);
+      });
+      custList.style.display = 'block';
+    }, 250);
+  });
+
+  function selectCustomer(c){
+    custName.value = c.name;
+    custPhone.value = c.phone || '';
+    document.getElementById('discountPct').value = (c.discount_percent||0);
+    custList.style.display='none';
+    renderItems();
+  }
 
   function selectCategory(cat){
     currentCategory = cat;

--- a/templates/sales_tables.html
+++ b/templates/sales_tables.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% block title %}{{ _('Tables / الطاولات') }} — {{ branch_label }}{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <div>
+      <h3 class="mb-0">{{ _('Tables / الطاولات') }} — {{ branch_label }}</h3>
+      <small class="text-muted">{{ _('Select a table (1–50) / اختر طاولة') }}</small>
+    </div>
+    <div>
+      <a class="btn btn-outline-secondary" href="{{ url_for('sales') }}">← {{ _('Back / رجوع') }}</a>
+    </div>
+  </div>
+
+  <div class="row g-3">
+    {% for n in tables %}
+    <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+      <a class="card text-center text-decoration-none shadow-sm h-100 border-0"
+         href="{{ url_for('sales_table_invoice', branch_code=branch_code, table_no=n) }}">
+        <div class="card-body d-flex align-items-center justify-content-center" style="min-height: 80px;">
+          <div>
+            <div class="fw-bold" style="font-size: 1.25rem;">{{ n }}</div>
+            <div class="text-muted" style="font-size: .85rem;">{{ _('Table') }}</div>
+          </div>
+        </div>
+      </a>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}
+

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -49,6 +49,38 @@
       <input type="text" name="china_town_label" class="form-control" value="{{ s.china_town_label or 'China Town' }}">
     </div>
 
+    <hr class="my-4">
+    <h4>إعدادات الإيصال والطباعة</h4>
+    <div class="col-md-3">
+      <label class="form-label">عرض الورق (مم)</label>
+      <select name="receipt_paper_width" class="form-select">
+        <option value="80" {% if s.receipt_paper_width=='80' %}selected{% endif %}>80mm</option>
+        <option value="58" {% if s.receipt_paper_width=='58' %}selected{% endif %}>58mm</option>
+      </select>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">حجم الخط</label>
+      <input type="number" name="receipt_font_size" class="form-control" value="{{ s.receipt_font_size or 12 }}">
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">رابط الشعار (Logo URL)</label>
+      <input type="text" name="logo_url" class="form-control" value="{{ s.logo_url or '/static/chinese-logo.svg' }}">
+    </div>
+    <div class="col-md-6">
+      <div class="form-check mt-4">
+        <input class="form-check-input" type="checkbox" name="receipt_show_logo" id="recLogo" {% if s.receipt_show_logo %}checked{% endif %}>
+        <label class="form-check-label" for="recLogo">إظهار الشعار</label>
+      </div>
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" name="receipt_show_tax_number" id="recTax" {% if s.receipt_show_tax_number %}checked{% endif %}>
+        <label class="form-check-label" for="recTax">إظهار الرقم الضريبي</label>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">نص تذييل الإيصال</label>
+      <input type="text" name="receipt_footer_text" class="form-control" value="{{ s.receipt_footer_text or '' }}">
+    </div>
+
     <div class="col-12 d-flex justify-content-end gap-2">
       <a class="btn btn-secondary" href="{{ url_for('dashboard') }}">رجوع</a>
       <button class="btn btn-primary" type="submit">حفظ</button>


### PR DESCRIPTION
- POS flow: /sales shows branches, /sales/<branch>/tables (1–50), /sales/<branch>/table/<no> split UI with live items and Pay&Print
- Customer auto-fill via /api/customers/lookup (discount percent, phone)
- Seed default menu categories once; use MenuCategory if present
- Thermal receipt with logo, tax number, QR placeholder; settings to control logo/print options
- Settings: add logo_url and receipt controls

Note: DB changes require migrations for customers, menu_categories, and Settings.logo_url.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author