### PR TITLE
ops: fix auto migrations to use Flask-Migrate upgrade() on Render

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,10 +75,9 @@ socketio = SocketIO(app)
 try:
     if os.getenv('RENDER') == 'true' or os.getenv('RENDER'):
         with app.app_context():
-            from alembic.config import Config
-            from alembic import command as _al_cmd
-            alembic_cfg = Config(os.path.join(os.path.dirname(__file__), 'migrations', 'alembic.ini'))
-            _al_cmd.upgrade(alembic_cfg, 'head')
+            # Use Flask-Migrate API so env.py/current_app config is respected
+            from flask_migrate import upgrade as _fm_upgrade
+            _fm_upgrade()
 except Exception as _migr_err:
     # Do not crash app if migrations fail; logs help diagnose
     logging.error('Auto migration failed: %s', _migr_err, exc_info=True)


### PR DESCRIPTION
Replace direct Alembic Config/command calls with Flask-Migrate upgrade() so env.py and Flask config are respected on Render. This fixes the "No 'script_location' key found" error and lets auto-migrations run safely at startup.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author