### PR TITLE
fix: Add pytz==2022.7 to fix compatibility issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,6 @@ python-bidi>=0.4.2
 
 # Optional: QR code image generation for ZATCA TLV on receipts
 qrcode[pil]>=7.4.2
+
+# Fix pytz compatibility issue
+pytz==2022.7


### PR DESCRIPTION
- Resolves pytz version conflict
- Ensures stable timezone handling
- Compatible with current Flask/Python setup