### PR TITLE
fix(procfile): use wsgi_simple instead of eventlet to avoid crashes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -k eventlet -w 1 -b 0.0.0.0:$PORT wsgi:application
+web: gunicorn --worker-class sync --workers 1 -b 0.0.0.0:$PORT wsgi_simple:application


### PR DESCRIPTION
- Change from eventlet worker to sync worker
- Use wsgi_simple:application instead of wsgi:application
- This should prevent the flask_migrate errors and worker crashes