### PR TITLE
fix(migrations): resolve Alembic context issues for Render deployment

### DIFF
--- a/run_migrations.py
+++ b/run_migrations.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+Run database migrations safely within Flask app context
+"""
+import os
+import sys
+
+# Disable eventlet for CLI operations
+os.environ['USE_EVENTLET'] = '0'
+os.environ['DISABLE_SOCKETIO'] = '1'
+
+def run_migrations():
+    """Run Flask-Migrate upgrade within app context"""
+    try:
+        print("[run_migrations] Creating Flask app...")
+        from app import create_app
+        app = create_app()
+        
+        print("[run_migrations] Running migrations within app context...")
+        with app.app_context():
+            from flask_migrate import upgrade
+            upgrade()
+            print("[run_migrations] ✅ Migrations completed successfully!")
+            
+    except Exception as e:
+        print(f"[run_migrations] ❌ Migration failed: {e}")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    run_migrations()

--- a/scripts/start_render_simple.sh
+++ b/scripts/start_render_simple.sh
@@ -13,9 +13,12 @@ export WORKERS=${WORKERS:-1}
 export PORT=${PORT:-10000}
 export FLASK_APP=app
 
-echo "[start_render_simple] Applying Alembic migrations..."
-if ! python -m flask db upgrade heads; then
-  echo "[start_render_simple] WARNING: flask db upgrade failed; continuing anyway"
+echo "[start_render_simple] Applying database migrations..."
+if ! python run_migrations.py; then
+  echo "[start_render_simple] WARNING: run_migrations.py failed; trying flask db upgrade..."
+  if ! python -m flask db upgrade heads; then
+    echo "[start_render_simple] WARNING: both migration methods failed; continuing anyway"
+  fi
 fi
 
 echo "[start_render_simple] Running DB consistency fixes (best-effort)..."


### PR DESCRIPTION
- Fix migrations/env.py to use DATABASE_URL directly instead of Flask context
- Add run_migrations.py as backup migration script with proper app context
- Update start_render_simple.sh to try both migration methods
- Remove dependency on current_app.extensions during migrations
- This should resolve the flask_migrate errors seen in Render logs