### PR TITLE
fix(migrations): merge all migration heads and create proper alembic.ini

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = ${DATABASE_URL}
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/merge_heads.py
+++ b/merge_heads.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""
+Merge multiple Alembic heads into a single head
+"""
+import os
+import sys
+
+# Disable eventlet for CLI operations
+os.environ['USE_EVENTLET'] = '0'
+os.environ['DISABLE_SOCKETIO'] = '1'
+
+def merge_heads():
+    """Merge all heads into a single head"""
+    try:
+        print("[merge_heads] Setting up Flask app context...")
+        from app import create_app
+        app = create_app()
+        
+        print("[merge_heads] Merging heads within app context...")
+        with app.app_context():
+            from flask_migrate import merge
+
+            # The heads we found
+            heads = ['097c20248414', '20250909_03', '4539af27efad', '9fd032f321c7']
+
+            print(f"[merge_heads] Merging heads: {heads}")
+            # Flask-Migrate merge syntax: merge(revisions, message)
+            merge(revisions=heads, message="merge all migration heads")
+            print("[merge_heads] ✅ Heads merged successfully!")
+            
+    except Exception as e:
+        print(f"[merge_heads] ❌ Merge failed: {e}")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    merge_heads()

--- a/migrations/versions/76d4fbfc7862_merge_all_migration_heads.py
+++ b/migrations/versions/76d4fbfc7862_merge_all_migration_heads.py
@@ -1,0 +1,24 @@
+"""merge all migration heads
+
+Revision ID: 76d4fbfc7862
+Revises: 097c20248414, 20250909_03, 4539af27efad, 9fd032f321c7
+Create Date: 2025-09-10 09:12:35.925936
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '76d4fbfc7862'
+down_revision = ('097c20248414', '20250909_03', '4539af27efad', '9fd032f321c7')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
- Create clean alembic.ini with proper DATABASE_URL configuration
- Add merge_heads.py script to safely merge multiple heads
- Successfully merged 4 heads into single head: 76d4fbfc7862
- Now have single migration head instead of multiple conflicting heads
- This should resolve migration conflicts on Render deployment